### PR TITLE
Add GA tracker if enabled

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,5 +37,7 @@
         {{ end }}
 
         {{ partial "js.html" . }}
+
+        {{ template "_internal/google_analytics.html" . }}
     </body>
 </html>


### PR DESCRIPTION
Per the documentation: https://discuss.gohugo.io/t/implementing-google-analytics-in-hugo/2671/2

If you set a top-level `googleAnalytics` key, we should enable it.

This PR does that.