### PR TITLE
Allow 'about' button to have link

### DIFF
--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -12,9 +12,10 @@
                 {{ with .Site.Params.about.description }}
                     <p class="text-faded">{{ . | markdownify }}</p>
                 {{ end }}
-                {{ with .Site.Params.about.buttonText }}
-                    <a href="#" class="btn btn-default btn-xl">{{ . }}</a>
-                {{ end }}
+
+                <a href="{{ .Site.Params.about.link }}" class="btn btn-default btn-xl">
+                  {{ .Site.Params.about.buttonText }}
+                </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The 'about' button is inconsistent with the 'aside' button, in that it doesn't allow a link. This PR allows the 'about' button to have a link URL.